### PR TITLE
Improve progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Esta aplicación permite extraer información de productos desde múltiples siti
         ```
     *   **Celery Worker:**
         ```bash
-        celery -A backend.main.celery_app worker --loglevel=info
+        # Ajusta "-c" para lanzar múltiples procesos y acelerar el scraping
+        celery -A backend.main.celery_app worker -c 4 --loglevel=info
         ```
     *   **FastAPI Server:**
         ```bash
@@ -59,6 +60,8 @@ Esta aplicación permite extraer información de productos desde múltiples siti
 5.  **Abrir el frontend:**
     Abre el archivo `frontend/index.html` en tu navegador.
 
-Los datos extraídos se guardan tanto en `results.jsonl` como en la base de datos
-SQLite `scraper.db` para mantener un registro persistente de todos los productos
-procesados.
+Los datos extraídos se guardan tanto en `results.jsonl` como en la base de datos SQLite `scraper.db` (o la ruta especificada en la variable de entorno `SCRAPER_DB`) para mantener un registro persistente de todos los productos procesados.
+
+## Seguimiento de progreso
+
+Al iniciar un trabajo, el backend calcula primero cuántas URLs se van a procesar y expone esa información a través del endpoint `/scrape/status/{task_id}`. El frontend muestra desde el principio el total de URLs y va actualizando el número de exitos y fallos conforme avanzan los workers.

--- a/backend/main.py
+++ b/backend/main.py
@@ -167,7 +167,7 @@ async def get_scraping_status(task_id: str):
             success_count = group_result.successful_count()
             failure_count = group_result.failed_count()
             completed_count = success_count + failure_count
-            
+
             progress_percent = (completed_count / total_urls * 100) if total_urls > 0 else 0
 
             response['progress'] = {
@@ -177,8 +177,17 @@ async def get_scraping_status(task_id: str):
                 "failed": failure_count,
                 "percent": f"{progress_percent:.2f}%"
             }
-    
-    elif main_task.state == 'SUCCESS' and 'status' in task_info:
-        response['progress'] = task_info
+    else:
+        # Si aún no se ha lanzado el grupo de tareas pero ya conocemos el total
+        if total_urls:
+            response['progress'] = {
+                "total": total_urls,
+                "completed": 0,
+                "success": 0,
+                "failed": 0,
+                "percent": "0%",
+            }
+        elif main_task.state == 'SUCCESS' and 'status' in task_info:
+            response['progress'] = task_info
 
     return response


### PR DESCRIPTION
## Summary
- show progress details before celery group starts
- document how to spawn multiple celery workers
- mention configurable DB path and progress tracking in README

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688cff142420832b8a1aa5f0170f6832