### PR TITLE
feat: track job results

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Esta aplicación permite extraer información de productos desde múltiples siti
 5.  **Abrir el frontend:**
     Abre el archivo `frontend/index.html` en tu navegador.
 
-Los datos extraídos se guardan tanto en `results.jsonl` como en la base de datos SQLite `scraper.db` (o la ruta especificada en la variable de entorno `SCRAPER_DB`) para mantener un registro persistente de todos los productos procesados.
+Los datos extraídos se guardan tanto en `results.jsonl` como en la base de datos SQLite `scraper.db` (o la ruta especificada en la variable de entorno `SCRAPER_DB`).
+La base de datos almacena cada trabajo de scraping y sus resultados asociados, lo que permite consultar los datos por `task_id` mediante el endpoint `/scrape/results/{task_id}`.
 
 ## Seguimiento de progreso
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,23 +1,68 @@
 import os
-from sqlalchemy import create_engine, Column, Integer, String, JSON
-from sqlalchemy.orm import declarative_base, sessionmaker
+from typing import List, Optional
+from sqlalchemy import create_engine, Column, Integer, String, JSON, ForeignKey
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
 
 DB_PATH = os.getenv("SCRAPER_DB", "scraper.db")
 engine = create_engine(f"sqlite:///{DB_PATH}", echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
 
-class Product(Base):
-    __tablename__ = "products"
+
+class Job(Base):
+    __tablename__ = "jobs"
+    id = Column(String, primary_key=True, index=True)
+    total_urls = Column(Integer, default=0)
+    status = Column(String, default="PENDING")
+    results = relationship("JobResult", back_populates="job", cascade="all, delete-orphan")
+
+
+class JobResult(Base):
+    __tablename__ = "job_results"
     id = Column(Integer, primary_key=True, index=True)
-    url = Column(String, unique=True, nullable=False)
-    data = Column(JSON, nullable=False)
+    job_id = Column(String, ForeignKey("jobs.id"), index=True, nullable=False)
+    url = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    data = Column(JSON, nullable=True)
+
+    job = relationship("Job", back_populates="results")
+
 
 def init_db() -> None:
     Base.metadata.create_all(bind=engine)
 
-def save_product(data: dict) -> None:
+
+def create_job(job_id: str, total: int) -> None:
     with SessionLocal() as session:
-        product = Product(url=data.get("url", ""), data=data)
-        session.merge(product)
+        job = Job(id=job_id, total_urls=total, status="RUNNING")
+        session.merge(job)
         session.commit()
+
+
+def update_job_status(job_id: str, status: str) -> None:
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        if job:
+            job.status = status
+            session.commit()
+
+
+def save_result(job_id: str, url: str, data: Optional[dict], status: str) -> None:
+    with SessionLocal() as session:
+        result = JobResult(job_id=job_id, url=url, data=data, status=status)
+        session.add(result)
+        session.commit()
+
+
+def get_results_by_job(job_id: str) -> List[dict]:
+    with SessionLocal() as session:
+        results = session.query(JobResult).filter_by(job_id=job_id).all()
+        return [
+            {"url": r.url, "status": r.status, "data": r.data}
+            for r in results
+        ]
+
+
+def job_exists(job_id: str) -> bool:
+    with SessionLocal() as session:
+        return session.query(Job).filter_by(id=job_id).first() is not None

--- a/scraper/storage.py
+++ b/scraper/storage.py
@@ -1,5 +1,5 @@
 """Helpers for persisting scraped data."""
-from typing import Any
+from typing import Optional
 from backend import database
 
 # Ensure database is initialised when this module is imported
@@ -8,7 +8,7 @@ try:
 except Exception:  # pragma: no cover - best effort
     pass
 
-def save_product(data: dict) -> None:
-    """Persist a single product dictionary into the SQLite database."""
-    database.save_product(data)
 
+def save_product(job_id: str, url: str, data: Optional[dict], status: str) -> None:
+    """Persist a single result dictionary into the SQLite database."""
+    database.save_result(job_id, url, data, status)


### PR DESCRIPTION
## Summary
- persist every scraping job and its URL results in SQLite
- expose `/scrape/results/{task_id}` to fetch stored job results
- update storage layer to save results with job context

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e63d88d60832b9551f1d7e838588b