### PR TITLE
feat: manage scraping jobs and progress

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,6 @@
 import os
 from typing import List, Optional
+
 from sqlalchemy import create_engine, Column, Integer, String, JSON, ForeignKey
 from sqlalchemy.orm import declarative_base, sessionmaker, relationship
 
@@ -14,6 +15,8 @@ class Job(Base):
     id = Column(String, primary_key=True, index=True)
     total_urls = Column(Integer, default=0)
     status = Column(String, default="PENDING")
+    urls = Column(JSON, nullable=True)
+    task_group_id = Column(String, nullable=True)
     results = relationship("JobResult", back_populates="job", cascade="all, delete-orphan")
 
 
@@ -32,9 +35,10 @@ def init_db() -> None:
     Base.metadata.create_all(bind=engine)
 
 
-def create_job(job_id: str, total: int) -> None:
+def create_job(job_id: str, total: int, urls: List[str]) -> None:
+    """Create or update a job entry with the initial set of URLs."""
     with SessionLocal() as session:
-        job = Job(id=job_id, total_urls=total, status="RUNNING")
+        job = Job(id=job_id, total_urls=total, status="RUNNING", urls=urls)
         session.merge(job)
         session.commit()
 
@@ -45,6 +49,19 @@ def update_job_status(job_id: str, status: str) -> None:
         if job:
             job.status = status
             session.commit()
+
+
+def update_job_group(job_id: str, group_id: str) -> None:
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        if job:
+            job.task_group_id = group_id
+            session.commit()
+
+
+def get_job(job_id: str) -> Optional[Job]:
+    with SessionLocal() as session:
+        return session.get(Job, job_id)
 
 
 def save_result(job_id: str, url: str, data: Optional[dict], status: str) -> None:
@@ -64,5 +81,24 @@ def get_results_by_job(job_id: str) -> List[dict]:
 
 
 def job_exists(job_id: str) -> bool:
+    return get_job(job_id) is not None
+
+
+def delete_job(job_id: str) -> None:
     with SessionLocal() as session:
-        return session.query(Job).filter_by(id=job_id).first() is not None
+        job = session.get(Job, job_id)
+        if job:
+            session.delete(job)
+            session.commit()
+
+
+def get_pending_urls(job_id: str) -> List[str]:
+    """Return URLs that have not yet been processed for a given job."""
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        if not job or not job.urls:
+            return []
+        processed = {
+            r.url for r in session.query(JobResult.url).filter_by(job_id=job_id)
+        }
+        return [url for url in job.urls if url not in processed]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,21 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.backend
-    command: celery -A backend.main.celery_app worker --loglevel=info -P solo
+    command: celery -A backend.main.celery_app worker --loglevel=info -c 4
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    networks:
+      - scraper-network
+
+  worker2:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    command: celery -A backend.main.celery_app worker --loglevel=info -c 4
     volumes:
       - .:/app
     depends_on:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,21 +21,31 @@ https://www.ejemplo2.com"></textarea>
                 <button id="start-scrape-btn">Iniciar Scraping</button>
             </div>
 
-            <div class="status-section">
-                <h2>Estado del Trabajo</h2>
-                <p id="job-status">En espera...</p>
-                <div class="progress-bar-container">
-                    <div id="progress-bar"></div>
+                <div class="status-section">
+                    <h2>Estado del Trabajo</h2>
+                    <p id="job-status">En espera...</p>
+                    <div class="progress-bar-container">
+                        <div id="progress-bar"></div>
+                    </div>
+                    <p id="progress-text"></p>
+                    <div id="progress-details"></div>
+                    <div class="controls">
+                        <button id="pause-btn" disabled>Pausar</button>
+                        <button id="resume-btn" disabled>Reanudar</button>
+                        <button id="stop-btn" disabled>Detener</button>
+                        <button id="download-btn" disabled>Descargar JSON</button>
+                    </div>
                 </div>
-                <p id="progress-text"></p>
-                <div id="progress-details"></div>
-            </div>
 
-            <div class="results-section">
-                <h2>Resultados</h2>
-                <p>Los resultados se guardarán en el archivo <code>results.jsonl</code> en la raíz del proyecto.</p>
-                <button id="download-excel-btn" disabled>Exportar a Excel (Próximamente)</button>
-            </div>
+                <div class="results-section">
+                    <h2>Resultados</h2>
+                    <table id="results-table">
+                        <thead>
+                            <tr><th>URL</th><th>Estado</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
         </main>
 
         <footer>


### PR DESCRIPTION
## Summary
- persist discovered URLs per job and track group id for resuming
- add job control endpoints (pause, resume, stop, delete, download)
- frontend shows progress, partial results, and allows controlling jobs
- scale workers via docker-compose for faster URL distribution

## Testing
- `python -m py_compile backend/main.py backend/database.py`


------
https://chatgpt.com/codex/tasks/task_e_688e66a1561c832b8b1b7da67d9b7faf