### PR TITLE
Improve job debug features and add stop control

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,7 +39,7 @@ database.init_db()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Permite todos los orígenes (cuidado en producción)
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],  # Permite todos los métodos (GET, POST, etc.)
     allow_headers=["*"],  # Permite todas las cabeceras
 )

--- a/frontend-react/src/services/api.ts
+++ b/frontend-react/src/services/api.ts
@@ -48,7 +48,6 @@ export interface StartScrapingResponse {
 export interface JobStatusResponse {
   task_id: string;
   status: string;
-  info: any;
   progress?: {
     total: number;
     completed: number;
@@ -56,6 +55,7 @@ export interface JobStatusResponse {
     failed: number;
     percent: string;
   };
+  error?: string;
 }
 
 export interface HealthCheckResponse {
@@ -83,6 +83,11 @@ export const apiService = {
     return response.data;
   },
 
+  // Stop job
+  async stopJob(taskId: string): Promise<void> {
+    await api.post(`/scrape/stop/${taskId}`);
+  },
+
   // Get all jobs (if we implement this endpoint later)
   async getAllJobs(): Promise<any[]> {
     try {
@@ -92,15 +97,6 @@ export const apiService = {
       // If endpoint doesn't exist yet, return empty array
       console.warn('Jobs endpoint not available yet');
       return [];
-    }
-  },
-
-  // Cancel job (if we implement this endpoint later)
-  async cancelJob(taskId: string): Promise<void> {
-    try {
-      await api.delete(`/scrape/${taskId}`);
-    } catch (error) {
-      console.warn('Cancel job endpoint not available yet');
     }
   },
 


### PR DESCRIPTION
## Summary
- fix CORS configuration on backend
- add job stop endpoint to API service
- enhance dashboard with error handling and stop button

## Testing
- `python -m py_compile backend/main.py backend/database.py`
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_688e6df490f4832ba232d1239275e595