### PR TITLE
Handle task status retrieval errors

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -200,8 +200,12 @@ async def get_scraping_status(task_id: str):
 
     error_detail = None
     if job.status == "FAILED":
-        async_result = celery_app.AsyncResult(task_id)
-        error_detail = str(async_result.info)
+        try:
+            async_result = celery_app.AsyncResult(task_id)
+            error_detail = str(async_result.info)
+        except Exception as e:  # pragma: no cover - safety net for unreachable backend
+            logging.exception("[Status] Error retrieving task result")
+            error_detail = f"Unable to fetch error details: {e}"
 
     return {
         "task_id": task_id,


### PR DESCRIPTION
## Summary
- guard `/scrape/status/{task_id}` against Celery backend failures

## Testing
- `pytest`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688e76b12208832bb4945e907b88b1b8