### PR TITLE
fix: ensure CORS headers and update proxy config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     depends_on:
       - backend
     environment:
-      - REACT_APP_API_URL=http://localhost:8000
+      - REACT_APP_API_URL=/api
     networks:
       - scraper-network
 

--- a/frontend-react/src/services/api.ts
+++ b/frontend-react/src/services/api.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 // API Configuration
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+// Default to the proxy path when running inside Docker to avoid CORS issues.
+const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- always attach CORS headers to backend responses and handle unexpected errors
- route frontend API calls through Nginx proxy to avoid cross-origin issues
- use proxy path in docker-compose for frontend builds

## Testing
- `python -m py_compile backend/main.py`
- `npm --prefix frontend-react test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e79e919d0832bab965f07f7174a7e