### PR TITLE
Fix proxy path for API requests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,9 +8,15 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Redirigir las llamadas a la API al servicio de backend
-    location /scrape {
-        proxy_pass http://backend:8000;
+    # Proxy API requests to the backend service
+    #
+    # Using a dedicated /api/ prefix keeps frontend assets and API calls
+    # separated.  The trailing slashes in both the location and the
+    # proxy_pass ensure that the remainder of the path is forwarded
+    # unchanged to the FastAPI application running on the backend
+    # container.
+    location /api/ {
+        proxy_pass http://backend:8000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- proxy `/api/` requests to backend service to avoid 502 errors

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688e8209c7c4832bb67655dca3d97cd6