### PR TITLE
fix: preserve http errors in middleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,9 @@ async def add_cors_headers(request: Request, call_next):
     """Garantiza cabeceras CORS incluso en respuestas de error."""
     try:
         response = await call_next(request)
+    except HTTPException as exc:
+        # Preserve FastAPI HTTP exceptions and status codes
+        response = JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
     except Exception as exc:  # pragma: no cover - protección ante errores inesperados
         logging.exception("Unhandled server error: %s", exc)
         response = JSONResponse({"detail": "Internal Server Error"}, status_code=500)


### PR DESCRIPTION
## Summary
- fix middleware to return original HTTP errors instead of masking them as 500

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e84706710832ba650f9426911d534