### PR TITLE
Register job before scraping begins

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -35,10 +35,30 @@ def init_db() -> None:
     Base.metadata.create_all(bind=engine)
 
 
-def create_job(job_id: str, total: int, urls: List[str]) -> None:
-    """Create or update a job entry with the initial set of URLs."""
+def create_job(
+    job_id: str,
+    total: int = 0,
+    urls: Optional[List[str]] = None,
+    status: str = "RUNNING",
+) -> None:
+    """Create or update a job entry.
+
+    Parameters
+    ----------
+    job_id:
+        Identifier of the job.
+    total:
+        Total number of URLs that will be processed. Defaults to ``0`` so a
+        job can be created before the discovery phase finishes.
+    urls:
+        Optional list of URLs discovered for this job.
+    status:
+        Initial status for the job. By default jobs start in ``RUNNING`` but a
+        caller may pass ``"PENDING"`` to register the job before any work has
+        begun.
+    """
     with SessionLocal() as session:
-        job = Job(id=job_id, total_urls=total, status="RUNNING", urls=urls)
+        job = Job(id=job_id, total_urls=total, status=status, urls=urls)
         session.merge(job)
         session.commit()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -193,6 +193,13 @@ async def create_scraping_job(req: ScrapeRequest):
     if not req.domains:
         raise HTTPException(status_code=400, detail="La lista de dominios no puede estar vacía.")
     task = start_scraping_task.delay(req.domains)
+
+    # Registrar inmediatamente el job en la base de datos para que el
+    # frontend pueda consultar su estado sin esperar a que Celery descubra
+    # las URLs. El número total y la lista de URLs se actualizarán una vez que
+    # la tarea principal haya terminado la fase de descubrimiento.
+    database.create_job(task.id, status="PENDING")
+
     return {"message": "Trabajo de scraping iniciado", "task_id": task.id}
 
 


### PR DESCRIPTION
## Summary
- allow `create_job` to accept optional URLs and status so jobs can be registered early
- record a job as `PENDING` when `/scrape` is called before Celery discovers URLs

## Testing
- `pytest`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688e8aa1e158832b946dbe225cc8133a