### PR TITLE
feat: unify scraping UI with progress tracking and autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ La base de datos almacena cada trabajo de scraping y sus resultados asociados, l
 ## Seguimiento de progreso
 
 Al iniciar un trabajo, el backend calcula primero cuántas URLs se van a procesar y expone esa información a través del endpoint `/scrape/status/{task_id}`. El frontend muestra desde el principio el total de URLs y va actualizando el número de exitos y fallos conforme avanzan los workers.
+
+## Escalado dinámico de workers
+
+Cuando se ejecuta con Docker Compose, el backend ajusta automáticamente la cantidad de contenedores `worker` para mantener cinco procesos por cada trabajo activo. Al finalizar o cancelar un trabajo, los contenedores sobrantes se detienen, liberando recursos sin intervención manual.

--- a/backend/database.py
+++ b/backend/database.py
@@ -141,6 +141,11 @@ def get_results_by_job(job_id: str) -> List[dict]:
         ]
 
 
+def count_jobs_by_status(status: str) -> int:
+    with SessionLocal() as session:
+        return session.query(Job).filter_by(status=status).count()
+
+
 def job_exists(job_id: str) -> bool:
     return get_job(job_id) is not None
 

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1,0 +1,27 @@
+import os
+import importlib
+
+
+def test_scale_worker_containers(monkeypatch, tmp_path):
+    os.environ["SCRAPER_DB"] = str(tmp_path / "test.db")
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    from backend import database
+    importlib.reload(database)
+    database.init_db()
+    import backend.main as main
+    importlib.reload(main)
+
+    database.create_job("job1", total=1, urls=["u"], status="RUNNING")
+
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+    main.scale_worker_containers()
+    assert calls[-1][4] == "worker=1"
+
+    database.update_job_status("job1", "COMPLETED")
+    main.scale_worker_containers()
+    assert calls[-1][4] == "worker=0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,21 +27,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.backend
-    command: celery -A backend.main.celery_app worker --loglevel=info -c 4
-    volumes:
-      - .:/app
-    depends_on:
-      - redis
-    env_file:
-      - .env
-    networks:
-      - scraper-network
-
-  worker2:
-    build:
-      context: .
-      dockerfile: Dockerfile.backend
-    command: celery -A backend.main.celery_app worker --loglevel=info -c 4
+    command: >-
+      celery -A backend.main.celery_app worker --loglevel=info -c ${WORKER_CONCURRENCY:-5}
     volumes:
       - .:/app
     depends_on:

--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -29,7 +29,8 @@
         "react-scripts": "5.0.1",
         "recharts": "^3.1.0",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "xlsx": "^0.18.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5122,6 +5123,15 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -6250,6 +6260,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6481,6 +6504,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -6718,6 +6750,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -9284,6 +9328,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -16242,6 +16295,18 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -18213,6 +18278,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -18618,6 +18701,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -24,7 +24,8 @@
     "react-scripts": "5.0.1",
     "recharts": "^3.1.0",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend-react/src/App.test.tsx
+++ b/frontend-react/src/App.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+jest.mock('./services/api', () => ({ apiService: { healthCheck: jest.fn() } }));
 
-test('renders learn react link', () => {
+test('renders scraper dashboard', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Web Scraper Dashboard/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { CssBaseline, Box } from '@mui/material';
 import Navbar from './components/Navbar';
-import Dashboard from './pages/Dashboard';
-import ScrapingJobs from './pages/ScrapingJobs';
-import Analytics from './pages/Analytics';
-import Settings from './pages/Settings';
 import { ScrapingProvider } from './context/ScrapingContext';
+import UnifiedScraperPage from './pages/UnifiedScraperPage';
 
 // Create a client for React Query
 const queryClient = new QueryClient({
@@ -78,19 +74,12 @@ function App() {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <ScrapingProvider>
-          <Router>
-            <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-              <Navbar />
-              <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-                <Routes>
-                  <Route path="/" element={<Dashboard />} />
-                  <Route path="/jobs" element={<ScrapingJobs />} />
-                  <Route path="/analytics" element={<Analytics />} />
-                  <Route path="/settings" element={<Settings />} />
-                </Routes>
-              </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+            <Navbar />
+            <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+              <UnifiedScraperPage />
             </Box>
-          </Router>
+          </Box>
         </ScrapingProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/frontend-react/src/components/Navbar.tsx
+++ b/frontend-react/src/components/Navbar.tsx
@@ -1,61 +1,19 @@
-import React, { useState } from 'react';
-import {
-  AppBar,
-  Toolbar,
-  Typography,
-  Button,
-  IconButton,
-  Badge,
-  Menu,
-  MenuItem,
-  Box,
-  Chip,
-  Avatar,
-  Tooltip,
-} from '@mui/material';
-import {
-  Dashboard as DashboardIcon,
-  Work as WorkIcon,
-  Analytics as AnalyticsIcon,
-  Settings as SettingsIcon,
-  Notifications as NotificationsIcon,
-  PlayArrow as PlayIcon,
-  Stop as StopIcon,
-  BugReport as BugIcon,
-} from '@mui/icons-material';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React from 'react';
+import { AppBar, Toolbar, Typography, Box, Chip, Tooltip } from '@mui/material';
+import { BugReport as BugIcon, PlayArrow as PlayIcon, Stop as StopIcon } from '@mui/icons-material';
 import { useScraping } from '../context/ScrapingContext';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/api';
 
 const Navbar: React.FC = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { state } = useScraping();
-  const [notificationAnchor, setNotificationAnchor] = useState<null | HTMLElement>(null);
 
-  // Health check query
-  const { data: healthData, isError: healthError } = useQuery({
+  const { isError: healthError } = useQuery({
     queryKey: ['health'],
     queryFn: apiService.healthCheck,
-    refetchInterval: 30000, // Check every 30 seconds
+    refetchInterval: 30000,
     retry: 1,
   });
-
-  const navigationItems = [
-    { path: '/', label: 'Dashboard', icon: <DashboardIcon /> },
-    { path: '/jobs', label: 'Jobs', icon: <WorkIcon /> },
-    { path: '/analytics', label: 'Analytics', icon: <AnalyticsIcon /> },
-    { path: '/settings', label: 'Settings', icon: <SettingsIcon /> },
-  ];
-
-  const handleNotificationClick = (event: React.MouseEvent<HTMLElement>) => {
-    setNotificationAnchor(event.currentTarget);
-  };
-
-  const handleNotificationClose = () => {
-    setNotificationAnchor(null);
-  };
 
   const getStatusColor = () => {
     if (healthError) return 'error';
@@ -74,15 +32,14 @@ const Navbar: React.FC = () => {
   const failedJobs = state.jobs.filter(job => job.status === 'failed').length;
 
   return (
-    <AppBar 
-      position="sticky" 
-      sx={{ 
+    <AppBar
+      position="sticky"
+      sx={{
         background: 'linear-gradient(135deg, #1a1f2e 0%, #2d3748 100%)',
         borderBottom: '1px solid #2d3748',
       }}
     >
       <Toolbar>
-        {/* Logo and Title */}
         <Box sx={{ display: 'flex', alignItems: 'center', mr: 4 }}>
           <BugIcon sx={{ mr: 1, color: 'primary.main' }} />
           <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
@@ -90,29 +47,9 @@ const Navbar: React.FC = () => {
           </Typography>
         </Box>
 
-        {/* Navigation Items */}
-        <Box sx={{ display: 'flex', gap: 1, flexGrow: 1 }}>
-          {navigationItems.map((item) => (
-            <Button
-              key={item.path}
-              startIcon={item.icon}
-              onClick={() => navigate(item.path)}
-              sx={{
-                color: location.pathname === item.path ? 'primary.main' : 'text.secondary',
-                backgroundColor: location.pathname === item.path ? 'rgba(0, 212, 170, 0.1)' : 'transparent',
-                '&:hover': {
-                  backgroundColor: 'rgba(0, 212, 170, 0.05)',
-                },
-              }}
-            >
-              {item.label}
-            </Button>
-          ))}
-        </Box>
+        <Box sx={{ flexGrow: 1 }} />
 
-        {/* Status Indicators */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          {/* System Status */}
           <Tooltip title={`System Status: ${getStatusText()}`}>
             <Chip
               label={getStatusText()}
@@ -123,7 +60,6 @@ const Navbar: React.FC = () => {
             />
           </Tooltip>
 
-          {/* Active Jobs Counter */}
           {runningJobs > 0 && (
             <Tooltip title={`${runningJobs} jobs running`}>
               <Chip
@@ -136,7 +72,6 @@ const Navbar: React.FC = () => {
             </Tooltip>
           )}
 
-          {/* Completed Jobs Counter */}
           {completedJobs > 0 && (
             <Tooltip title={`${completedJobs} jobs completed`}>
               <Chip
@@ -148,7 +83,6 @@ const Navbar: React.FC = () => {
             </Tooltip>
           )}
 
-          {/* Failed Jobs Counter */}
           {failedJobs > 0 && (
             <Tooltip title={`${failedJobs} jobs failed`}>
               <Chip
@@ -159,65 +93,7 @@ const Navbar: React.FC = () => {
               />
             </Tooltip>
           )}
-
-          {/* Notifications */}
-          <Tooltip title="Notifications">
-            <IconButton
-              color="inherit"
-              onClick={handleNotificationClick}
-              sx={{ color: 'text.secondary' }}
-            >
-              <Badge badgeContent={state.error ? 1 : 0} color="error">
-                <NotificationsIcon />
-              </Badge>
-            </IconButton>
-          </Tooltip>
-
-          {/* User Avatar */}
-          <Avatar
-            sx={{
-              width: 32,
-              height: 32,
-              bgcolor: 'primary.main',
-              fontSize: '0.875rem',
-            }}
-          >
-            U
-          </Avatar>
         </Box>
-
-        {/* Notifications Menu */}
-        <Menu
-          anchorEl={notificationAnchor}
-          open={Boolean(notificationAnchor)}
-          onClose={handleNotificationClose}
-          PaperProps={{
-            sx: {
-              mt: 1,
-              minWidth: 300,
-              maxWidth: 400,
-            },
-          }}
-        >
-          {state.error ? (
-            <MenuItem onClick={handleNotificationClose}>
-              <Box>
-                <Typography variant="subtitle2" color="error">
-                  System Error
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {state.error}
-                </Typography>
-              </Box>
-            </MenuItem>
-          ) : (
-            <MenuItem onClick={handleNotificationClose}>
-              <Typography variant="body2" color="text.secondary">
-                No new notifications
-              </Typography>
-            </MenuItem>
-          )}
-        </Menu>
       </Toolbar>
     </AppBar>
   );

--- a/frontend-react/src/pages/UnifiedScraperPage.tsx
+++ b/frontend-react/src/pages/UnifiedScraperPage.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import { Box, Typography, TextField, Button, LinearProgress, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+import { apiService } from '../services/api';
+import * as XLSX from 'xlsx';
+
+interface JobInfo {
+  id: string;
+  url: string;
+  status: string;
+  progress?: {
+    total: number;
+    completed: number;
+    success: number;
+    failed: number;
+    percent: string;
+  };
+}
+
+export const UnifiedScraperPage: React.FC = () => {
+  const [urlInput, setUrlInput] = useState('');
+  const [jobs, setJobs] = useState<JobInfo[]>([]);
+  const [results, setResults] = useState<any[]>([]);
+
+  // Start scraping for each URL entered
+  const handleStart = async () => {
+    const urls = urlInput
+      .split(/\n|,|;|\s+/)
+      .map((u) => u.trim())
+      .filter((u) => u);
+    for (const url of urls) {
+      try {
+        const resp = await apiService.startScraping({ domains: [url] });
+        const job: JobInfo = { id: resp.task_id, url, status: 'PENDING' };
+        setJobs((prev) => [...prev, job]);
+        pollStatus(resp.task_id);
+        pollResults(resp.task_id);
+      } catch (e) {
+        console.error('Failed to start job for', url, e);
+      }
+    }
+    setUrlInput('');
+  };
+
+  // Poll status for a job
+  const pollStatus = (taskId: string) => {
+    const interval = setInterval(async () => {
+      try {
+        const status = await apiService.getJobStatus(taskId);
+        setJobs((prev) =>
+          prev.map((j) => (j.id === taskId ? { ...j, status: status.status, progress: status.progress } : j))
+        );
+        if (status.status === 'COMPLETED' || status.status === 'FAILED' || status.status === 'CANCELLED') {
+          clearInterval(interval);
+        }
+      } catch (err) {
+        console.error('Status polling error', err);
+      }
+    }, 2000);
+  };
+
+  // Poll results for a job
+  const pollResults = (taskId: string) => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await apiService.getJobResults(taskId);
+        if (res && (res as any).results) {
+          const rows = (res as any).results.map((r: any) => ({ ...r, job_id: taskId }));
+          setResults((prev) => {
+            const others = prev.filter((p) => p.job_id !== taskId);
+            return [...others, ...rows];
+          });
+        }
+      } catch (err) {
+        console.error('Results polling error', err);
+      }
+    }, 2000);
+  };
+
+  const handleDownload = () => {
+    const ws = XLSX.utils.json_to_sheet(results);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Results');
+    XLSX.writeFile(wb, 'scraper_results.xlsx');
+  };
+
+  const handleStopAll = async () => {
+    for (const job of jobs) {
+      try {
+        await apiService.stopJob(job.id);
+      } catch (e) {
+        console.error('Failed to stop job', job.id, e);
+      }
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 1000, mx: 'auto' }}>
+      <Typography variant="h4" sx={{ mb: 2, fontWeight: 600 }}>
+        Web Scraper Dashboard
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        <TextField
+          label="Enter website URLs (one per line)"
+          multiline
+          rows={3}
+          fullWidth
+          value={urlInput}
+          onChange={(e) => setUrlInput(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleStart} sx={{ alignSelf: 'flex-start', mt: 1 }}>
+          Start
+        </Button>
+      </Box>
+      <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
+        <Button variant="outlined" onClick={handleDownload} disabled={results.length === 0}>
+          Download Excel
+        </Button>
+        <Button color="error" variant="outlined" onClick={handleStopAll} disabled={jobs.length === 0}>
+          Stop All
+        </Button>
+      </Box>
+      {jobs.map((job) => (
+        <Box key={job.id} sx={{ mb: 2 }}>
+          <Typography variant="subtitle1">{job.url}</Typography>
+          {job.progress && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Box sx={{ flexGrow: 1 }}>
+                <LinearProgress
+                  variant="determinate"
+                  value={job.progress.total ? (job.progress.completed / job.progress.total) * 100 : 0}
+                />
+              </Box>
+              <Typography variant="body2">
+                {job.progress.completed}/{job.progress.total}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      ))}
+      {results.length > 0 && (
+        <TableContainer component={Paper} sx={{ mt: 4 }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Job</TableCell>
+                <TableCell>URL</TableCell>
+                <TableCell>Data</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {results.map((row, idx) => (
+                <TableRow key={idx}>
+                  <TableCell>{row.job_id}</TableCell>
+                  <TableCell>{row.url || row.product_url || 'n/a'}</TableCell>
+                  <TableCell>{row.title || JSON.stringify(row)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default UnifiedScraperPage;


### PR DESCRIPTION
## Summary
- auto-scale Docker worker containers to provision five Celery workers per scraping job
- coordinate worker pool with job lifecycle and document autoscaling behavior
- add regression test for scaling logic

## Testing
- `CI=true npm test --silent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e95a17bd8832bae2c76fd3611a2d9