### PR TITLE
Improve worker scaling and results table UX

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -36,8 +36,13 @@ celery_app.conf.update(
 app = FastAPI(title="Scraper API", version="1.0.0")
 database.init_db()
 
-WORKERS_PER_JOB = int(os.getenv("WORKERS_PER_JOB", "5"))
-WORKER_CONTAINER_CONCURRENCY = int(os.getenv("WORKER_CONCURRENCY", "5"))
+# Cada trabajo de scraping requiere tres procesos de worker por defecto. De este
+# modo se puede ajustar con variables de entorno en despliegues diferentes, pero
+# si no se especifica se garantizan tres workers por job como mínimo.
+WORKERS_PER_JOB = int(os.getenv("WORKERS_PER_JOB", "3"))
+# Cada contenedor de worker ejecuta también tres procesos de Celery por defecto
+# para que el número total de procesos coincida con el multiplicador anterior.
+WORKER_CONTAINER_CONCURRENCY = int(os.getenv("WORKER_CONCURRENCY", "3"))
 
 
 def scale_worker_containers() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     command: >-
-      celery -A backend.main.celery_app worker --loglevel=info -c ${WORKER_CONCURRENCY:-5}
+      celery -A backend.main.celery_app worker --loglevel=info -c ${WORKER_CONCURRENCY:-3}
     volumes:
       - .:/app
     depends_on:


### PR DESCRIPTION
## Summary
- default Celery to 3 workers per job and adjust compose configuration
- paginate results table, pretty-print scraped data and export a flattened Excel

## Testing
- `pytest`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688eadcde780832bb7dcfab3fec2d328