### PR TITLE
feat: add vercel deployment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY="your_openai_key"
+SCRAPER_DB="scraper.db"
+BLOB_READ_WRITE_TOKEN="your_blob_read_write_token"
+EDGE_CONFIG="your_edge_config_connection_string"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 *.py[cod]
 scraper.db
+node_modules/
+frontend-react/build

--- a/README.md
+++ b/README.md
@@ -70,3 +70,34 @@ Al iniciar un trabajo, el backend calcula primero cuántas URLs se van a procesa
 ## Escalado dinámico de workers
 
 Cuando se ejecuta con Docker Compose, el backend ajusta automáticamente la cantidad de contenedores `worker` para mantener cinco procesos por cada trabajo activo. Al finalizar o cancelar un trabajo, los contenedores sobrantes se detienen, liberando recursos sin intervención manual.
+
+## Despliegue en Vercel
+
+El proyecto incluye configuración para desplegar el frontend de React y funciones serverless en [Vercel](https://vercel.com).
+
+1. **Variables de entorno**
+   - `OPENAI_API_KEY`: clave de OpenAI.
+   - `SCRAPER_DB`: ruta a la base de datos (opcional).
+   - `BLOB_READ_WRITE_TOKEN`: token de lectura/escritura para Vercel Blob.
+   - `EDGE_CONFIG`: cadena de conexión de Edge Config.
+
+   Puedes copiar `.env.example` a `.env` y completar los valores. Luego sincroniza con Vercel:
+   ```bash
+   vercel env pull
+   ```
+
+2. **Instalar dependencias de las funciones**
+   ```bash
+   npm --prefix api install
+   ```
+
+3. **Desplegar**
+   ```bash
+   vercel deploy
+   ```
+
+Las funciones disponibles son:
+
+- `api/upload.js`: permite subir contenidos a [Vercel Blob](https://vercel.com/docs/storage/vercel-blob).
+- `api/welcome.js`: lee valores de [Edge Config](https://vercel.com/docs/storage/edge-config).
+

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,136 @@
+{
+  "name": "api",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api",
+      "dependencies": {
+        "@vercel/blob": "^1.1.1",
+        "@vercel/edge-config": "^1.4.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@vercel/blob": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-1.1.1.tgz",
+      "integrity": "sha512-heiJGj2qt5qTv6yiShH9f6KRAoZGj+lz61GQ+lBRL4lhvUmKI9A51KYlQTnsUd9ymdFlKHBlvmPeG+yGz2Qsbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@vercel/edge-config": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-1.4.0.tgz",
+      "integrity": "sha512-69Wg5gw9DzwnyUmnjToSeLRm1nm8mCPgN0kflX8EHRHyqvzH80wPem5A8rI2LXPb2Y9tJNoqN3vXPcQhS2Wh5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/edge-config-fs": "0.1.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "api",
+  "type": "module",
+  "dependencies": {
+    "@vercel/blob": "^1.1.1",
+    "@vercel/edge-config": "^1.4.0"
+  }
+}

--- a/api/upload.js
+++ b/api/upload.js
@@ -1,0 +1,19 @@
+import { put } from '@vercel/blob';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+  try {
+    const { path, content, access = 'public' } = req.body || {};
+    if (!path || !content) {
+      res.status(400).json({ error: 'Missing path or content' });
+      return;
+    }
+    const { url } = await put(path, content, { access, token: process.env.BLOB_READ_WRITE_TOKEN });
+    res.status(200).json({ url });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/api/welcome.js
+++ b/api/welcome.js
@@ -1,0 +1,10 @@
+import { get } from '@vercel/edge-config';
+
+export default async function handler(req, res) {
+  try {
+    const greeting = await get('greeting');
+    res.status(200).json(greeting);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "builds": [
+    { "src": "api/**/*.[jt]s", "use": "@vercel/node" },
+    {
+      "src": "frontend-react/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "build" }
+    }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Vercel builds and routes for React frontend and serverless functions
- add blob upload and edge config API endpoints
- document environment variables and Vercel deployment steps

## Testing
- `pytest`
- `CI=true npm --prefix frontend-react test`


------
https://chatgpt.com/codex/tasks/task_e_688ebf257ecc832bab46615d66d9a48f