### PR TITLE
fix: remove unused variables causing build failure

### DIFF
--- a/frontend-react/src/components/Navbar.tsx
+++ b/frontend-react/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AppBar, Toolbar, Typography, Box, Chip, Tooltip } from '@mui/material';
-import { BugReport as BugIcon, PlayArrow as PlayIcon, Stop as StopIcon } from '@mui/icons-material';
+import { BugReport as BugIcon, PlayArrow as PlayIcon } from '@mui/icons-material';
 import { useScraping } from '../context/ScrapingContext';
 import { useQuery } from '@tanstack/react-query';
 import { apiService } from '../services/api';

--- a/frontend-react/src/pages/UnifiedScraperPage.tsx
+++ b/frontend-react/src/pages/UnifiedScraperPage.tsx
@@ -85,7 +85,7 @@ export const UnifiedScraperPage: React.FC = () => {
 
   // Poll results for a job
   const pollResults = (taskId: string) => {
-    const interval = setInterval(async () => {
+    setInterval(async () => {
       try {
         const res = await apiService.getJobResults(taskId);
         if (res && (res as any).results) {


### PR DESCRIPTION
## Summary
- remove unused StopIcon import from navbar
- drop unused interval variable in unified scraper page

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ec2568950832b95e68ea5922130cf