### PR TITLE
feat: add proxy for backend api

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1,0 +1,31 @@
+const BACKEND_URL = process.env.SCRAPER_API_URL || 'http://localhost:8000';
+
+export default async function handler(req, res) {
+  const { path = [] } = req.query;
+  const target = `${BACKEND_URL}/${Array.isArray(path) ? path.join('/') : path}`;
+
+  const init = {
+    method: req.method,
+    headers: { ...req.headers, host: undefined },
+  };
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+    init.headers['Content-Type'] = 'application/json';
+  }
+
+  try {
+    const response = await fetch(target, init);
+    const contentType = response.headers.get('content-type') || '';
+    res.status(response.status);
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      res.json(data);
+    } else {
+      const text = await response.text();
+      res.send(text);
+    }
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add catch-all API route that proxies requests to backend defined by `SCRAPER_API_URL`

## Testing
- `npm --prefix frontend-react test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee0553c4c832b9c0f28ad9a7a6daa