### PR TITLE
Add health check endpoint to FastAPI backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -105,6 +105,12 @@ async def add_cors_headers(request: Request, call_next):
     response.headers.setdefault("Access-Control-Allow-Methods", "*")
     return response
 
+
+@app.get("/", summary="Health check")
+async def read_root():
+    """Simple health check endpoint for monitoring purposes."""
+    return {"status": "ok", "message": "Scraper API is running"}
+
 class ScrapeRequest(BaseModel):
     domains: list[str]
 

--- a/backend/test_health.py
+++ b/backend/test_health.py
@@ -1,0 +1,22 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+
+
+def create_app(tmp_path):
+    os.environ["SCRAPER_DB"] = str(tmp_path / "test.db")
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    from backend import database
+    importlib.reload(database)
+    database.init_db()
+    import backend.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_root_health_check(tmp_path):
+    app = create_app(tmp_path)
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add root '/' endpoint returning simple health check response
- test health check with FastAPI TestClient

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5c135a68832bbf333a91bb01dd5c