### PR TITLE
fix: use local API in development

### DIFF
--- a/frontend-react/src/services/api.ts
+++ b/frontend-react/src/services/api.ts
@@ -1,8 +1,12 @@
 import axios from 'axios';
 
 // API Configuration
-// Default to the proxy path when running inside Docker to avoid CORS issues.
-const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
+// When developing locally we talk directly to the FastAPI backend running on
+// port 8000. In production (or when a specific URL is provided) we keep the
+// ``/api`` prefix so that requests can be proxied by Nginx/Vercel.
+const API_BASE_URL =
+  process.env.REACT_APP_API_URL ||
+  (process.env.NODE_ENV === 'development' ? 'http://localhost:8000' : '/api');
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- default API calls to the FastAPI backend on localhost in development mode, while preserving `/api` proxy path for production

## Testing
- `npm test --prefix frontend-react -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688f5c135a68832bbf333a91bb01dd5c