### PR TITLE
Fix API catch-all path and enhance dialog accessibility

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,30 @@
+const BACKEND_URL = process.env.SCRAPER_API_URL || 'http://localhost:8000';
+
+export default async function handler(req, res) {
+  const target = `${BACKEND_URL}/`;
+
+  const init = {
+    method: req.method,
+    headers: { ...req.headers, host: undefined },
+  };
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+    init.headers['Content-Type'] = 'application/json';
+  }
+
+  try {
+    const response = await fetch(target, init);
+    const contentType = response.headers.get('content-type') || '';
+    res.status(response.status);
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      res.json(data);
+    } else {
+      const text = await response.text();
+      res.send(text);
+    }
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/frontend-react/src/pages/Dashboard.tsx
+++ b/frontend-react/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  DialogContentText,
   DialogActions,
   List,
   ListItem,
@@ -446,6 +447,9 @@ const Dashboard: React.FC = () => {
       <Dialog open={newJobDialog} onClose={() => setNewJobDialog(false)} maxWidth="sm" fullWidth>
         <DialogTitle>Start New Scraping Job</DialogTitle>
         <DialogContent>
+          <DialogContentText>
+            Enter one domain per line to start a new scraping job.
+          </DialogContentText>
           <TextField
             autoFocus
             margin="dense"

--- a/frontend-react/src/pages/ScrapingJobs.tsx
+++ b/frontend-react/src/pages/ScrapingJobs.tsx
@@ -20,6 +20,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  DialogContentText,
   DialogActions,
   LinearProgress,
   Tooltip,
@@ -325,6 +326,9 @@ const ScrapingJobs: React.FC = () => {
           Job Details: {selectedJob?.id.slice(0, 8)}...
         </DialogTitle>
         <DialogContent>
+          <DialogContentText>
+            Detailed information about the selected scraping job.
+          </DialogContentText>
           {selectedJob && (
             <Box sx={{ mt: 2 }}>
               <Box display="flex" flexWrap="wrap" gap={3}>

--- a/frontend-react/src/pages/Settings.tsx
+++ b/frontend-react/src/pages/Settings.tsx
@@ -21,6 +21,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  DialogContentText,
   DialogActions,
 } from '@mui/material';
 import {
@@ -443,10 +444,10 @@ const Settings: React.FC = () => {
       <Dialog open={resetDialog} onClose={() => setResetDialog(false)}>
         <DialogTitle>Reset Settings</DialogTitle>
         <DialogContent>
-          <Typography>
-            Are you sure you want to reset all settings to their default values? 
+          <DialogContentText>
+            Are you sure you want to reset all settings to their default values?
             This action cannot be undone.
-          </Typography>
+          </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setResetDialog(false)}>Cancel</Button>

--- a/frontend-react/src/services/api.ts
+++ b/frontend-react/src/services/api.ts
@@ -72,7 +72,7 @@ export interface HealthCheckResponse {
 export const apiService = {
   // Health check
   async healthCheck(): Promise<HealthCheckResponse> {
-    const response = await api.get('/');
+    const response = await api.get('');
     return response.data;
   },
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,10 @@
   "buildCommand": "npm --prefix frontend-react run build",
   "outputDirectory": "frontend-react/build",
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/api", "destination": "/api/index.js" },
+    { "source": "/api/(.*)", "destination": "/api/[...path].js?path=$1" },
+    { "source": "/static/(.*)", "destination": "/frontend-react/build/static/$1" },
+    { "source": "/manifest.json", "destination": "/frontend-react/build/manifest.json" },
     { "source": "/(.*)", "destination": "/frontend-react/build/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure `/api` requests are routed by adding explicit index handler and restoring catch-all proxy
- expand Vercel rewrites to serve API routes and static assets
- avoid trailing slashes in health check requests

## Testing
- `npm --prefix frontend-react test -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f64dea198832bb3f146e6a9f1e82f