### PR TITLE
feat: handle missing backend on vercel

### DIFF
--- a/api/[[...path]].js
+++ b/api/[[...path]].js
@@ -1,7 +1,17 @@
-const BACKEND_URL = process.env.SCRAPER_API_URL || 'http://localhost:8000';
+// ``SCRAPER_API_URL`` must be provided when running on Vercel. Locally we fall
+// back to the development server on ``localhost``.
+const BACKEND_URL =
+  process.env.SCRAPER_API_URL ||
+  (process.env.VERCEL ? undefined : 'http://localhost:8000');
 
 export default async function handler(req, res) {
   const { path = [] } = req.query;
+
+  if (!BACKEND_URL) {
+    res.status(503).json({ error: 'SCRAPER_API_URL not configured' });
+    return;
+  }
+
   const target = `${BACKEND_URL}/${Array.isArray(path) ? path.join('/') : path}`;
 
   const init = {
@@ -26,6 +36,8 @@ export default async function handler(req, res) {
       res.send(text);
     }
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    res
+      .status(502)
+      .json({ error: 'Unable to reach backend', detail: error.message });
   }
 }


### PR DESCRIPTION
## Summary
- handle missing backend URL gracefully for health check and proxy calls

## Testing
- `npm --prefix api test` *(fails: Missing script: "test")*
- `npm --prefix frontend-react test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9d6e904c832bacd3cf756e43f1a3