### PR TITLE
fix: handle missing backend and static asset paths

### DIFF
--- a/api/[[...path]].js
+++ b/api/[[...path]].js
@@ -8,7 +8,9 @@ export default async function handler(req, res) {
   const { path = [] } = req.query;
 
   if (!BACKEND_URL) {
-    res.status(503).json({ error: 'SCRAPER_API_URL not configured' });
+    res
+      .status(200)
+      .json({ status: 'error', message: 'SCRAPER_API_URL not configured' });
     return;
   }
 
@@ -36,8 +38,10 @@ export default async function handler(req, res) {
       res.send(text);
     }
   } catch (error) {
+    // When the backend is unreachable we still return HTTP 200 so the frontend
+    // can surface a clear message instead of failing the request entirely.
     res
-      .status(502)
-      .json({ error: 'Unable to reach backend', detail: error.message });
+      .status(200)
+      .json({ status: 'error', message: 'Unable to reach backend', detail: error.message });
   }
 }

--- a/frontend-react/src/services/api.ts
+++ b/frontend-react/src/services/api.ts
@@ -79,7 +79,15 @@ export const apiService = {
   // Start scraping job
   async startScraping(request: StartScrapingRequest): Promise<StartScrapingResponse> {
     const response = await api.post('/scrape', request);
-    return response.data;
+    const data = response.data;
+    // When the backend is not configured or returns an error, the proxy API
+    // responds with an ``error``/``status`` field instead of the expected
+    // ``task_id``. Surface this as a rejected promise so callers can handle it
+    // gracefully.
+    if (!data?.task_id) {
+      throw new Error(data?.message || data?.error || 'SCRAPER_API_URL not configured');
+    }
+    return data;
   },
 
   // Get job status

--- a/vercel.json
+++ b/vercel.json
@@ -8,8 +8,6 @@
       "source": "/api/(.*)",
       "destination": "/api/[[...path]].js?path=$1"
     },
-    { "source": "/static/(.*)", "destination": "/frontend-react/build/static/$1" },
-    { "source": "/manifest.json", "destination": "/frontend-react/build/manifest.json" },
-    { "source": "/(.*)", "destination": "/frontend-react/build/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- avoid 503s by returning a clear message when SCRAPER_API_URL is missing
- detect missing task id in client and throw a helpful error
- simplify vercel rewrites so static assets like manifest.json are served correctly

## Testing
- `npm --prefix api test` *(fails: Missing script: "test")*
- `npm --prefix frontend-react test -- --watchAll=false`
- `npm --prefix frontend-react run build`


------
https://chatgpt.com/codex/tasks/task_e_689033d0ee8c832bb81f3582834641e9