### PR TITLE
I've addressed two issues related to your Vercel deployment with this…

### DIFF
--- a/api/[[...path]].js
+++ b/api/[[...path]].js
@@ -8,9 +8,11 @@ export default async function handler(req, res) {
   const { path = [] } = req.query;
 
   if (!BACKEND_URL) {
-    res
-      .status(200)
-      .json({ status: 'error', message: 'SCRAPER_API_URL not configured' });
+    res.status(200).json({
+      status: 'error',
+      message:
+        'SCRAPER_API_URL not configured. Please set this environment variable in your Vercel project settings.',
+    });
     return;
   }
 

--- a/api/index.js
+++ b/api/index.js
@@ -11,9 +11,11 @@ export default async function handler(req, res) {
   // environment variable configured) return a friendly health‑check response
   // instead of a 500 error.
   if (!BACKEND_URL) {
-    res
-      .status(200)
-      .json({ status: 'ok', message: 'SCRAPER_API_URL not configured' });
+    res.status(200).json({
+      status: 'ok',
+      message:
+        'SCRAPER_API_URL not configured. Please set this environment variable in your Vercel project settings.',
+    });
     return;
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,13 @@
   "outputDirectory": "frontend-react/build",
   "rewrites": [
     { "source": "/api", "destination": "/api/index.js" },
-    {
-      "source": "/api/(.*)",
-      "destination": "/api/[[...path]].js?path=$1"
-    },
+    { "source": "/api/(.*)", "destination": "/api/[[...path]].js?path=$1" },
+    { "source": "/static/(.*)", "destination": "/static/$1" },
+    { "source": "/manifest.json", "destination": "/manifest.json" },
+    { "source": "/favicon.ico", "destination": "/favicon.ico" },
+    { "source": "/robots.txt", "destination": "/robots.txt" },
+    { "source": "/logo192.png", "destination": "/logo192.png" },
+    { "source": "/logo512.png", "destination": "/logo512.png" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
… commit.

First, I improved the error message in the API proxy functions. When the `SCRAPER_API_URL` environment variable is not set on Vercel, the application would fail with a generic error. The error message is now more descriptive, explicitly telling you to set the environment variable in your Vercel project settings.

Second, I corrected the Vercel rewrite rules to prevent issues with static file serving. The previous catch-all SPA rewrite rule `/(.*)` was incorrectly intercepting requests for static assets like `manifest.json`, leading to 401 errors. I fixed this by adding pass-through rewrite rules for common static assets, ensuring they are served correctly before the SPA fallback is applied.