### PR TITLE
fix: ensure proxy API can reach backend

### DIFF
--- a/api/[[...path]].js
+++ b/api/[[...path]].js
@@ -1,3 +1,5 @@
+import fetch from 'node-fetch';
+
 // ``SCRAPER_API_URL`` must be provided when running on Vercel. Locally we fall
 // back to the development server on ``localhost``.
 const BACKEND_URL =

--- a/api/index.js
+++ b/api/index.js
@@ -1,3 +1,5 @@
+import fetch from 'node-fetch';
+
 // Determine backend URL. When running on Vercel the URL must be provided via
 // ``SCRAPER_API_URL``. For local development we fall back to the typical
 // ``localhost`` address so developers can run the backend separately without

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7,7 +7,8 @@
       "name": "api",
       "dependencies": {
         "@vercel/blob": "^1.1.1",
-        "@vercel/edge-config": "^1.4.0"
+        "@vercel/edge-config": "^1.4.0",
+        "node-fetch": "^3.3.2"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -70,6 +71,50 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -98,6 +143,44 @@
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -130,6 +213,15 @@
       },
       "engines": {
         "node": ">=14.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "dependencies": {
     "@vercel/blob": "^1.1.1",
-    "@vercel/edge-config": "^1.4.0"
+    "@vercel/edge-config": "^1.4.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/frontend-react/src/pages/UnifiedScraperPage.tsx
+++ b/frontend-react/src/pages/UnifiedScraperPage.tsx
@@ -13,6 +13,7 @@ import {
   TableRow,
   Paper,
   TablePagination,
+  Alert,
 } from '@mui/material';
 import { apiService } from '../services/api';
 import * as XLSX from 'xlsx';
@@ -35,6 +36,7 @@ export const UnifiedScraperPage: React.FC = () => {
   const [jobs, setJobs] = useState<JobInfo[]>([]);
   const [results, setResults] = useState<any[]>([]);
   const [page, setPage] = useState(0);
+  const [error, setError] = useState<string | null>(null);
   const rowsPerPage = 10;
   const dataKeys = useMemo(() => {
     const keys = new Set<string>();
@@ -60,6 +62,8 @@ export const UnifiedScraperPage: React.FC = () => {
         pollStatus(resp.task_id);
         pollResults(resp.task_id);
       } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        setError(`Failed to start job for ${url}: ${message}`);
         console.error('Failed to start job for', url, e);
       }
     }
@@ -127,6 +131,11 @@ export const UnifiedScraperPage: React.FC = () => {
 
   return (
     <Box sx={{ maxWidth: 1000, mx: 'auto' }}>
+      {error && (
+        <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
       <Typography variant="h4" sx={{ mb: 2, fontWeight: 600 }}>
         Web Scraper Dashboard
       </Typography>


### PR DESCRIPTION
## Summary
- polyfill `fetch` in serverless API routes so backend requests succeed in environments without native fetch
- show API connection failures in the dashboard using a dismissible alert

## Testing
- `npm --prefix api install`
- `npm install`
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890a6584144832b8b2820d8b20a7492