### PR TITLE
fix: remove duplicate header declarations

### DIFF
--- a/api/[[...path]].js
+++ b/api/[[...path]].js
@@ -23,20 +23,12 @@ export default async function handler(req, res) {
 
   const headers = { ...req.headers };
   // Drop hop-by-hop headers which can cause ``fetch`` to reject the request or
-  // forward incorrect values to the backend service.  ``fetch`` will populate
+  // forward incorrect values to the backend service. ``fetch`` will populate
   // the right ``Host`` header based on the target URL.
   delete headers.host;
   delete headers.connection;
   delete headers['content-length'];
   delete headers['accept-encoding'];
-
-  const headers = { ...req.headers };
-  // Drop hop-by-hop headers which can cause ``fetch`` to reject the request or
-  // forward incorrect values to the backend service.  ``fetch`` will populate
-  // the right ``Host`` header based on the target URL.
-  delete headers.host;
-  delete headers.connection;
-  delete headers['content-length'];
 
   const init = {
     method: req.method,

--- a/api/index.js
+++ b/api/index.js
@@ -28,24 +28,14 @@ export default async function handler(req, res) {
 
   const headers = { ...req.headers };
   // ``host`` (and a few hop-by-hop headers) should not be forwarded when
-  // proxying requests.  Setting them to ``undefined`` can result in invalid
-  // values being sent which in turn breaks the connection.  Instead explicitly
+  // proxying requests. Setting them to ``undefined`` can result in invalid
+  // values being sent which in turn breaks the connection. Instead explicitly
   // remove them so ``fetch`` generates the appropriate headers for the target
   // backend.
   delete headers.host;
   delete headers.connection;
   delete headers['content-length'];
   delete headers['accept-encoding'];
-
-  const headers = { ...req.headers };
-  // ``host`` (and a few hop-by-hop headers) should not be forwarded when
-  // proxying requests.  Setting them to ``undefined`` can result in invalid
-  // values being sent which in turn breaks the connection.  Instead explicitly
-  // remove them so ``fetch`` generates the appropriate headers for the target
-  // backend.
-  delete headers.host;
-  delete headers.connection;
-  delete headers['content-length'];
 
   const init = {
     method: req.method,


### PR DESCRIPTION
## Summary
- fix duplicate header declaration in serverless API handler so proxy compiles
- fix same issue in catch-all handler for non-root API routes

## Testing
- `node --check api/index.js`
- `node --check api/[[...path]].js`
- `pytest -q`
- `cd frontend-react && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6890bb759b34832b9ccd527dfd32b338