### PR TITLE
Handle missing OpenAI API key gracefully

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -244,6 +244,8 @@ def read_root():
 async def create_scraping_job(req: ScrapeRequest):
     if not req.domains:
         raise HTTPException(status_code=400, detail="La lista de dominios no puede estar vacía.")
+    if not os.getenv("OPENAI_API_KEY"):
+        raise HTTPException(status_code=503, detail="OPENAI_API_KEY not configured")
     try:
         task = start_scraping_task.delay(req.domains)
     except Exception as exc:  # pragma: no cover - depende del entorno externo


### PR DESCRIPTION
## Summary
- Avoid initializing OpenAI client when `OPENAI_API_KEY` is absent and warn instead
- Skip extraction when the OpenAI client is not configured
- Return 503 if `/scrape` is called without `OPENAI_API_KEY`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890bb759b34832b9ccd527dfd32b338