### PR TITLE
feat: harden proxy to backend

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,4 +1,12 @@
-import fetch from 'node-fetch';
+// The serverless functions act purely as a lightweight proxy to the real
+// scraping backend.  Instead of relying on the client to recover from transient
+// network failures we handle retries here so that a single hiccup does not
+// immediately surface as "Unable to reach backend" in the UI.
+//
+// ``fetch`` is available as a global in the Vercel runtime (Node 18+) so we do
+// not need an external dependency.  Using the built‑in implementation also
+// keeps the bundle smaller and avoids mismatches between Node versions.
+
 
 // Determine backend URL. When running on Vercel the URL must be provided via
 // ``SCRAPER_API_URL``. For local development we fall back to the typical
@@ -23,8 +31,8 @@ export default async function handler(req, res) {
 
   // Build the target URL by removing the ``/api`` prefix from the incoming
   // request and forwarding any query string to the backend service.
-  const reqUrl = new URL(req.url, 'http://localhost');
-  const target = new URL(reqUrl.pathname.replace(/^\/api/, '') + reqUrl.search, BACKEND_URL);
+const reqUrl = new URL(req.url, 'http://localhost');
+const target = new URL(reqUrl.pathname.replace(/^\/api/, '') + reqUrl.search, BACKEND_URL);
 
   const headers = { ...req.headers };
   // ``host`` (and a few hop-by-hop headers) should not be forwarded when
@@ -47,8 +55,24 @@ export default async function handler(req, res) {
     init.headers['Content-Type'] = 'application/json';
   }
 
+  // ``fetch`` requests occasionally fail due to cold starts or brief network
+  // hiccups.  A small retry loop with a request timeout makes the proxy more
+  // resilient and avoids surfacing spurious errors to the user.
+  async function fetchWithRetry(url, options, retries = 2) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), 10000); // 10s timeout
+    try {
+      return await fetch(url, { ...options, signal: controller.signal });
+    } catch (err) {
+      if (retries <= 0) throw err;
+      return await fetchWithRetry(url, options, retries - 1);
+    } finally {
+      clearTimeout(id);
+    }
+  }
+
   try {
-    const response = await fetch(target, init);
+    const response = await fetchWithRetry(target, init);
     const contentType = response.headers.get('content-type') || '';
     res.status(response.status);
     if (contentType.includes('application/json')) {
@@ -63,6 +87,11 @@ export default async function handler(req, res) {
     // can surface a clear message instead of failing the request entirely.
     res
       .status(200)
-      .json({ status: 'error', message: 'Unable to reach backend', detail: error.message });
+      .json({
+        status: 'error',
+        message: 'Unable to reach backend',
+        detail: error.message,
+        target: target.toString(),
+      });
   }
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7,8 +7,7 @@
       "name": "api",
       "dependencies": {
         "@vercel/blob": "^1.1.1",
-        "@vercel/edge-config": "^1.4.0",
-        "node-fetch": "^3.3.2"
+        "@vercel/edge-config": "^1.4.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -71,50 +70,6 @@
         "retry": "0.13.1"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -143,44 +98,6 @@
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -213,15 +130,6 @@
       },
       "engines": {
         "node": ">=14.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "dependencies": {
     "@vercel/blob": "^1.1.1",
-    "@vercel/edge-config": "^1.4.0",
-    "node-fetch": "^3.3.2"
+    "@vercel/edge-config": "^1.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- switch serverless proxies to Node's built-in `fetch`
- add retry and timeout logic when forwarding requests
- include target URL in proxy error response and drop `node-fetch` dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c5d0cf18832b875a2ab433f02ab1