### PR TITLE
Improve crawler resilience and worker scaling

### DIFF
--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -12,6 +12,7 @@ def test_scale_worker_containers(monkeypatch, tmp_path):
     importlib.reload(main)
 
     database.create_job("job1", total=1, urls=["u"], status="RUNNING")
+    database.create_job("job2", total=1, urls=["u"], status="PENDING")
 
     calls = []
 
@@ -20,8 +21,9 @@ def test_scale_worker_containers(monkeypatch, tmp_path):
 
     monkeypatch.setattr(main.subprocess, "run", fake_run)
     main.scale_worker_containers()
-    assert calls[-1][4] == "worker=1"
+    assert calls[-1][4] == "worker=2"
 
     database.update_job_status("job1", "COMPLETED")
+    database.update_job_status("job2", "COMPLETED")
     main.scale_worker_containers()
     assert calls[-1][4] == "worker=0"

--- a/scraper/browser.py
+++ b/scraper/browser.py
@@ -1,60 +1,110 @@
 import asyncio
 import logging
 import random
-from playwright.async_api import async_playwright, TimeoutError as PWTimeout, Page, BrowserContext
+from typing import List
+
+import httpx
+from playwright.async_api import (
+    BrowserContext,
+    Page,
+    TimeoutError as PWTimeout,
+)
 
 # --- Configuración --- (Eventualmente mover a un archivo de config central)
 PAGE_TIMEOUT_MS = 30000  # 30 segundos
 MAX_FETCH_RETRY = 3
-HEADERS = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36 Scraper/2.0"}
+
+# Rotación básica de user agents para evitar bloqueos simples.
+USER_AGENTS: List[str] = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+]
+
+# Cabecera por defecto utilizada como base (se actualiza dinámicamente en cada petición)
+HEADERS = {"User-Agent": USER_AGENTS[0]}
+
+
+def get_random_user_agent() -> str:
+    """Devuelve un user agent aleatorio."""
+
+    return random.choice(USER_AGENTS)
+
+
+async def create_context(browser, *, proxy: str | None = None) -> BrowserContext:
+    """Crea un contexto de navegador con rotación de user agent y soporte de proxy."""
+
+    context = await browser.new_context(
+        user_agent=get_random_user_agent(),
+        proxy={"server": proxy} if proxy else None,
+    )
+    # Ocultar `navigator.webdriver` para reducir bloqueos básicos.
+    await context.add_init_script(
+        "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
+    )
+    return context
+
 
 async def get_html_from_url(context: BrowserContext, url: str) -> str | None:
-    """
-    Navega a una URL usando una página del contexto y devuelve su contenido HTML.
-    Incluye reintentos y manejo de errores.
-    """
-    page = None
+    """Obtiene el HTML de ``url`` usando Playwright y hace fallback a HTTP puro si falla."""
+
+    page: Page | None = None
     for attempt in range(MAX_FETCH_RETRY):
         try:
             page = await context.new_page()
-            # Bloquear recursos innecesarios para acelerar la carga
             await page.route(
                 "**/*",
-                lambda route: route.abort() if route.request.resource_type in ["image", "stylesheet", "font", "media"] else route.continue_()
+                lambda route: route.abort()
+                if route.request.resource_type in ["image", "stylesheet", "font", "media"]
+                else route.continue_(),
             )
 
             await page.goto(url, timeout=PAGE_TIMEOUT_MS, wait_until="domcontentloaded")
-            
-            # Espera a que la red esté inactiva para asegurarse de que el contenido dinámico se cargue
             await page.wait_for_load_state("networkidle", timeout=15000)
 
-            # A veces, un pequeño retardo adicional ayuda a capturar scripts de última hora
+            # Retardo aleatorio para simular navegación humana
             await asyncio.sleep(random.uniform(1, 2.5))
 
-            # Intentar cerrar banners de cookies de forma genérica
             await _handle_cookie_banners(page)
-
-            content = await page.content()
-            return content
+            return await page.content()
 
         except PWTimeout:
-            logging.warning(f"[Browser] Timeout en intento {attempt + 1}/{MAX_FETCH_RETRY} para {url}")
-        except Exception as e:
-            logging.error(f"[Browser] Error inesperado en intento {attempt + 1}/{MAX_FETCH_RETRY} para {url}: {e}")
+            logging.warning(
+                f"[Browser] Timeout en intento {attempt + 1}/{MAX_FETCH_RETRY} para {url}"
+            )
+        except Exception as exc:
+            logging.error(
+                f"[Browser] Error inesperado en intento {attempt + 1}/{MAX_FETCH_RETRY} para {url}: {exc}"
+            )
         finally:
             if page:
                 await page.close()
-        
-        # Espera exponencial antes de reintentar
+
         await asyncio.sleep((2 ** attempt) * 2)
 
-    logging.error(f"[Browser] No se pudo obtener el HTML de {url} después de {MAX_FETCH_RETRY} intentos.")
-    return None
+    logging.error(
+        f"[Browser] No se pudo obtener el HTML de {url} después de {MAX_FETCH_RETRY} intentos."
+    )
+
+    # Fallback usando httpx, útil cuando Playwright es bloqueado.
+    try:
+        async with httpx.AsyncClient(
+            timeout=PAGE_TIMEOUT_MS / 1000,
+            headers={"User-Agent": get_random_user_agent()},
+            follow_redirects=True,
+        ) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            return resp.text
+    except Exception as exc:
+        logging.error(f"[Browser] Fallback HTTP request failed for {url}: {exc}")
+        return None
+
 
 async def _handle_cookie_banners(page: Page):
-    """
-    Intenta detectar y hacer clic en botones de aceptar cookies de forma genérica.
-    """
+    """Intenta detectar y cerrar banners de cookies de forma genérica."""
+
     cookie_selectors = [
         '[id*="cookie"] a',
         '[class*="cookie"] a',
@@ -66,13 +116,14 @@ async def _handle_cookie_banners(page: Page):
     ]
     for selector in cookie_selectors:
         try:
-            # Usamos `locator` con un timeout corto para no ralentizar el proceso
             button = page.locator(selector).first
             if await button.is_visible(timeout=500):
                 await button.click(timeout=1000)
-                logging.info(f"[Browser] Banner de cookies cerrado con el selector: {selector}")
-                await asyncio.sleep(500) # Esperar a que el banner desaparezca
-                return # Salir en cuanto se encuentra y se hace clic en uno
+                logging.info(
+                    f"[Browser] Banner de cookies cerrado con el selector: {selector}"
+                )
+                await asyncio.sleep(0.5)
+                return
         except Exception:
-            # Es normal que muchos selectores fallen, así que no registramos error
+            # Es normal que muchos selectores fallen
             pass

--- a/scraper/crawler.py
+++ b/scraper/crawler.py
@@ -4,66 +4,125 @@ import gzip
 import re
 from urllib.parse import urljoin, urlparse
 from collections import deque
+
 import httpx
 from bs4 import BeautifulSoup
+from .browser import get_random_user_agent
 
 # --- Configuración ---
 MAX_PAGES_CRAWL = 500  # Límite para el rastreo manual
 REQUEST_TIMEOUT = 15
 SITEMAP_PATHS = ["/sitemap.xml", "/sitemap_index.xml", "/sitemap.xml.gz", "/wp-sitemap.xml"]
-HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"}
 
 # Expresiones regulares para filtrar URLs (simplificado)
 _EXCLUDE_EXT = re.compile(r"\.(?:png|jpe?g|gif|webp|avif|bmp|svg|css|js|pdf|zip|gz)$", re.I)
+_PRODUCT_RX = re.compile(r"/(?:p|product|producto|item|dp)/", re.I)
 
-async def _fetch_url(client: httpx.AsyncClient, url: str):
-    try:
-        response = await client.get(url, headers=HEADERS, follow_redirects=True)
-        response.raise_for_status()
-        if url.endswith('.gz'):
-            return gzip.decompress(response.content)
-        return response.text
-    except httpx.HTTPStatusError as e:
-        logging.warning(f"[Crawler] Error HTTP {e.response.status_code} al buscar {url}")
-    except Exception as e:
-        logging.error(f"[Crawler] Error al buscar {url}: {e}")
+
+async def _fetch_url(client: httpx.AsyncClient, url: str, max_retries: int = 3) -> str | bytes | None:
+    """Descarga ``url`` con reintentos y rotación de User-Agent."""
+
+    for attempt in range(max_retries):
+        headers = {"User-Agent": get_random_user_agent()}
+        try:
+            response = await client.get(url, headers=headers, follow_redirects=True)
+            response.raise_for_status()
+            if url.endswith(".gz"):
+                return gzip.decompress(response.content)
+            return response.text
+        except httpx.HTTPStatusError as e:
+            logging.warning(
+                f"[Crawler] Error HTTP {e.response.status_code} al buscar {url} (intento {attempt + 1})"
+            )
+            if e.response.status_code in {403, 429, 500, 503} and attempt < max_retries - 1:
+                await asyncio.sleep(2 ** attempt)
+                continue
+        except Exception as e:
+            logging.error(
+                f"[Crawler] Error al buscar {url}: {e} (intento {attempt + 1})"
+            )
+            if attempt < max_retries - 1:
+                await asyncio.sleep(2 ** attempt)
+                continue
+        break
     return None
+
+
+async def _discover_sitemaps_from_robots(client: httpx.AsyncClient, base_url: str) -> list[str]:
+    """Lee ``robots.txt`` y extrae entradas ``Sitemap`` si existen."""
+
+    robots_url = urljoin(base_url, "robots.txt")
+    content = await _fetch_url(client, robots_url)
+    if not content:
+        return []
+    sitemap_urls = []
+    for line in content.splitlines():
+        if line.lower().startswith("sitemap:"):
+            sitemap_urls.append(line.split(":", 1)[1].strip())
+    return sitemap_urls
+
 
 def _parse_sitemap(sitemap_content: str) -> list[str]:
     """Parsea el contenido de un sitemap (XML) y extrae las URLs."""
+
     urls = []
-    soup = BeautifulSoup(sitemap_content, 'xml')
-    for loc in soup.find_all('loc'):
+    soup = BeautifulSoup(sitemap_content, "xml")
+    for loc in soup.find_all("loc"):
         urls.append(loc.text.strip())
     return urls
 
+
 async def find_urls_via_sitemap(domain: str) -> list[str] | None:
     """Intenta encontrar y parsear sitemaps para un dominio."""
-    base_url = urljoin(domain, '/')
+
+    base_url = urljoin(domain, "/")
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
-        for path in SITEMAP_PATHS:
-            sitemap_url = urljoin(base_url, path)
+        candidates = [urljoin(base_url, p) for p in SITEMAP_PATHS]
+        candidates.extend(await _discover_sitemaps_from_robots(client, base_url))
+
+        all_urls: list[str] = []
+        for sitemap_url in candidates:
             logging.info(f"[Crawler] Buscando sitemap en: {sitemap_url}")
             content = await _fetch_url(client, sitemap_url)
-            if content:
-                logging.info(f"[Crawler] Sitemap encontrado en {sitemap_url}")
-                sitemap_urls = _parse_sitemap(content)
-                # Si es un sitemap de sitemaps, explorarlos
-                if any("sitemap" in u for u in sitemap_urls):
-                    nested_urls = await asyncio.gather(*[_fetch_url(client, u) for u in sitemap_urls])
-                    all_urls = []
-                    for sitemap_content in nested_urls:
-                        if sitemap_content:
-                            all_urls.extend(_parse_sitemap(sitemap_content))
-                    return all_urls
-                return sitemap_urls
-    return None
+            if not content:
+                continue
+            sitemap_urls = _parse_sitemap(content)
+
+            # Si es un sitemap de sitemaps, explorarlos recursivamente
+            nested = [u for u in sitemap_urls if "sitemap" in u]
+            if nested:
+                nested_contents = await asyncio.gather(
+                    *[_fetch_url(client, u) for u in nested]
+                )
+                for sitemap_content in nested_contents:
+                    if sitemap_content:
+                        sitemap_urls.extend(_parse_sitemap(sitemap_content))
+
+            all_urls.extend(sitemap_urls)
+
+        if not all_urls:
+            return None
+
+        # Eliminar duplicados conservando orden
+        seen = set()
+        unique_urls = []
+        for u in all_urls:
+            if u not in seen:
+                seen.add(u)
+                unique_urls.append(u)
+
+        product_urls = [u for u in unique_urls if _PRODUCT_RX.search(u)]
+        return product_urls or unique_urls
+
 
 async def find_urls_via_crawl(domain: str) -> list[str]:
     """Realiza un rastreo básico del sitio para encontrar URLs."""
-    logging.info(f"[Crawler] No se encontraron sitemaps, iniciando rastreo manual de {domain}")
+
+    logging.info(
+        f"[Crawler] No se encontraron sitemaps, iniciando rastreo manual de {domain}"
+    )
     urls_found = set()
-    queue = deque([urljoin(domain, '/')])
+    queue = deque([urljoin(domain, "/")])
     base_netloc = urlparse(domain).netloc
 
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
@@ -75,37 +134,46 @@ async def find_urls_via_crawl(domain: str) -> list[str]:
             content = await _fetch_url(client, url)
             if not content:
                 continue
-            
+
             urls_found.add(url)
-            logging.info(f"[Crawler] Rastreado: {url} ({len(urls_found)}/{MAX_PAGES_CRAWL})")
+            logging.info(
+                f"[Crawler] Rastreado: {url} ({len(urls_found)}/{MAX_PAGES_CRAWL})"
+            )
 
-            soup = BeautifulSoup(content, 'lxml')
-            for link in soup.find_all('a', href=True):
-                href = link['href']
+            soup = BeautifulSoup(content, "lxml")
+            for link in soup.find_all("a", href=True):
+                href = link["href"]
                 abs_url = urljoin(url, href)
-                # Limpiar fragmentos y parámetros de consulta (opcional, pero ayuda)
-                abs_url = abs_url.split('#')[0].split('?')[0]
+                # Limpiar fragmentos y parámetros de consulta
+                abs_url = abs_url.split("#")[0].split("?")[0]
 
-                if urlparse(abs_url).netloc == base_netloc and not _EXCLUDE_EXT.search(abs_url):
+                if (
+                    urlparse(abs_url).netloc == base_netloc
+                    and not _EXCLUDE_EXT.search(abs_url)
+                ):
                     if abs_url not in urls_found and abs_url not in queue:
                         queue.append(abs_url)
-    
+
     return list(urls_found)
+
 
 async def get_urls_for_domain(domain: str) -> list[str]:
     """Función principal que orquesta la búsqueda de URLs para un dominio."""
+
     logging.info(f"Iniciando descubrimiento de URLs para {domain}")
     urls = await find_urls_via_sitemap(domain)
     if not urls:
         urls = await find_urls_via_crawl(domain)
-    
-    # Filtro final para asegurar que solo procesamos URLs de productos (heurística)
-    product_keywords = ['/p/', '/producto/', '/product/', '/dp/', '/item/']
-    product_urls = [u for u in urls if any(kw in u for kw in product_keywords)]
+
+    product_urls = [u for u in urls if _PRODUCT_RX.search(u)]
 
     if product_urls:
-        logging.info(f"[Crawler] Se encontraron {len(product_urls)} URLs de producto potenciales para {domain}")
+        logging.info(
+            f"[Crawler] Se encontraron {len(product_urls)} URLs de producto potenciales para {domain}"
+        )
         return product_urls
     else:
-        logging.warning(f"[Crawler] No se encontraron URLs de producto específicas, se usarán todas las {len(urls)} URLs encontradas.")
+        logging.warning(
+            f"[Crawler] No se encontraron URLs de producto específicas, se usarán todas las {len(urls)} URLs encontradas."
+        )
         return urls


### PR DESCRIPTION
## Summary
- rotate user agents and add httpx fallback for pages that block Playwright
- discover sitemaps via robots.txt and filter product URLs more robustly
- scale workers based on pending jobs and scale as soon as jobs are registered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fdaacf94832b8f3acad9a0aab456